### PR TITLE
Added "AI tools for developers" block

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,15 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 
 ---
 
+## ✨ AI Tools for Developers
+- **[Supercode.sh](https://supercode.sh/)**: Cursor IDE extension for prompt enhancement, precise voice input, Cursor-rules presets, etc.
+- **[SpecStory](https://specstory.com/)**: Cursor/VS Code/Claude Code extension for summarizing context across chats with AI.
+- **[Task Master](https://github.com/eyaltoledano/claude-task-master)**: A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI.
+- **[Memory Bank](https://github.com/vanzan01/cursor-memory-bank)**: A token-optimized, hierarchical task management system that integrates with Cursor custom modes for efficient development workflows.
+- **[Context7](https://context7.com/)**: MCP server with up-to-date documentation for LLMs and AI code editors.
+
+---
+
 ## ✍️ AI Code Completion
 - **[GitHub Copilot](https://github.com/features/copilot)**: AI-driven code completion tool for real-time suggestions in IDEs.
 - **[Codeium](https://www.codeium.com/)**: AI-powered code autocompletion for multiple languages and IDEs.

--- a/readme.md
+++ b/readme.md
@@ -50,11 +50,11 @@ Ideal for developers, teams, researchers, and tech enthusiasts looking to levera
 ---
 
 ## ✨ AI Tools for Developers
-- **[Supercode.sh](https://supercode.sh/)**: Cursor IDE extension for prompt enhancement, precise voice input, Cursor-rules presets, etc.
-- **[SpecStory](https://specstory.com/)**: Cursor/VS Code/Claude Code extension for summarizing context across chats with AI.
+- **[Supercode.sh](https://supercode.sh/)**: Cursor extension that upgrades AI agent in Cursor with Architect Mode, precise voice input, prompt enhancement, etc.
+- **[SpecStory](https://specstory.com/)**: Cursor / VS Code / Claude Code extension for summarizing context across chats with AI and preserving / sharing tasks intents.
 - **[Task Master](https://github.com/eyaltoledano/claude-task-master)**: A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI.
-- **[Memory Bank](https://github.com/vanzan01/cursor-memory-bank)**: A token-optimized, hierarchical task management system that integrates with Cursor custom modes for efficient development workflows.
-- **[Context7](https://context7.com/)**: MCP server with up-to-date documentation for LLMs and AI code editors.
+- **[Memory Bank](https://github.com/vanzan01/cursor-memory-bank)**: A token-optimized, hierarchical task management system that integrates with Cursor for efficient multi-step development workflows.
+- **[Context7](https://context7.com/)**: MCP server with up-to-date documentation for LLMs and AI code editors with precise token-usage management.
 
 ---
 


### PR DESCRIPTION
I've noticed that a lot of popular tools to facilitate AI-driven development are missing. So, I suggest to add:
* Context7 - context7.com
* Memory Bank - https://github.com/vanzan01/cursor-memory-bank/
* Supercode - supercode.sh
* SpecStory - specstory.com
* Task Master - https://github.com/eyaltoledano/claude-task-master

I have tested and used each of these tools and they are really great, some of them are part of my daily workflow.